### PR TITLE
uber restructure

### DIFF
--- a/src/xian/methods/check_tx.py
+++ b/src/xian/methods/check_tx.py
@@ -1,0 +1,20 @@
+from cometbft.abci.v1beta3.types_pb2 import ResponseCheckTx
+from xian.utils import (
+    decode_transaction_bytes,
+    unpack_transaction,
+)
+import json
+
+def check_tx(self, raw_tx) -> ResponseCheckTx:
+    try:
+        tx = decode_transaction_bytes(raw_tx)
+        self.xian.validate_transaction(tx)
+        sender, signature, payload = unpack_transaction(tx)
+        if not verify(sender, payload, signature):
+            return ResponseCheckTx(code=ErrorCode)
+        payload_json = json.loads(payload)
+        if payload_json["chain_id"] != self.chain_id:
+            return ResponseCheckTx(code=ErrorCode)
+        return ResponseCheckTx(code=OkCode)
+    except Exception as e:
+        return ResponseCheckTx(code=ErrorCode, info=f"ERROR: {e}")

--- a/src/xian/methods/commit.py
+++ b/src/xian/methods/commit.py
@@ -1,0 +1,25 @@
+from cometbft.abci.v1beta3.types_pb2 import ResponseCommit
+from xian.driver_api import (
+    set_latest_block_hash,
+    set_latest_block_height
+)
+
+def commit(self) -> ResponseCommit:
+    # commit block to filesystem db
+    set_latest_block_hash(self.fingerprint_hash, self.driver)
+    set_latest_block_height(self.current_block_meta["height"], self.driver)
+
+    self.driver.hard_apply(str(self.current_block_meta["nanos"]))
+
+    # unset current_block_meta & cleanup
+    self.current_block_meta = None
+    self.fingerprint_hashes = []
+    self.fingerprint_hash = None
+    self.current_block_rewards = {}
+
+    retain_height = 0 
+    if self.pruning_enabled:
+        if self.current_block_meta["height"] > self.blocks_to_keep:
+            retain_height = self.current_block_meta["height"] - self.blocks_to_keep
+
+    return ResponseCommit(retain_height=retain_height)

--- a/src/xian/methods/echo.py
+++ b/src/xian/methods/echo.py
@@ -1,0 +1,6 @@
+from cometbft.abci.v1beta1.types_pb2 import ResponseEcho
+
+def echo(self, req) -> ResponseEcho:
+    r = ResponseEcho()
+    r.echo = req.message
+    return r

--- a/src/xian/methods/finalize_block.py
+++ b/src/xian/methods/finalize_block.py
@@ -1,0 +1,97 @@
+from cometbft.abci.v1beta3.types_pb2 import (
+    ResponseFinalizeBlock,
+    ExecTxResult
+)
+from xian.utils import (
+    encode_str,
+    decode_transaction_bytes,
+    unpack_transaction,
+    get_nanotime_from_block_time,
+    convert_binary_to_hex,
+    stringify_decimals,
+    hash_from_rewards,
+    verify,
+    hash_list,
+    hash_from_rewards
+)
+from xian.rewards import (
+    distribute_rewards,
+    distribute_static_rewards
+)
+from abci.application import ErrorCode
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+def finalize_block(self, req) -> ResponseFinalizeBlock:
+    nanos = get_nanotime_from_block_time(req.time)
+    hash = convert_binary_to_hex(req.hash)
+    height = req.height
+    tx_results = []
+    reward_writes = []
+
+    self.current_block_meta = {
+        "nanos": nanos,
+        "height": height,
+        "hash": hash,
+    }   
+
+    for tx in req.txs: 
+        try:
+            tx = decode_transaction_bytes(tx)
+            sender, signature, payload = unpack_transaction(tx)
+            if not verify(sender, payload, signature):
+                raise Exception("Invalid Signature") # Not really needed, because check_tx should catch this first, but just in case
+            # Attach metadata to the transaction
+            tx["b_meta"] = self.current_block_meta
+            result = self.xian.tx_processor.process_tx(tx, enabled_fees=self.enable_tx_fee)
+
+            if self.enable_tx_fee:
+                self.current_block_rewards[tx['b_meta']['hash']] = {
+                    "amount": result["stamp_rewards_amount"],
+                    "contract": result["stamp_rewards_contract"]
+                }
+
+            self.xian.set_nonce(tx)
+            tx_hash = result["tx_result"]["hash"]
+            self.fingerprint_hashes.append(tx_hash)
+            parsed_tx_result = json.dumps(stringify_decimals(result["tx_result"]))
+            logger.debug(f"parsed tx result : {parsed_tx_result}")
+            tx_results.append(ExecTxResult(code=result["tx_result"]["status"],data=encode_str(parsed_tx_result),gas_used=result["stamp_rewards_amount"]))
+        except Exception as e:
+            # Normally this cannot happen, but if it does, we need to catch it
+            logger.error(f"Fatal ERROR: {e}")
+            tx_results.append(ExecTxResult(code=ErrorCode, data=encode_str(f"ERROR: {e}"), gas_used=0))
+
+    if self.static_rewards:
+        try:
+            reward_writes.append(distribute_static_rewards(
+                driver=self.driver,
+                foundation_reward=self.static_rewards_amount_foundation,
+                master_reward=self.static_rewards_amount_validators,
+            ))
+        except Exception as e:
+            logger.error(f"STATIC REWARD ERROR: {e} for block")
+
+    if self.current_block_rewards:
+        for tx_hash, reward in self.current_block_rewards.items():
+            try:
+                reward_writes.append(distribute_rewards(
+                    stamp_rewards_amount=reward["amount"],
+                    stamp_rewards_contract=reward["contract"],
+                    driver=self.driver,
+                    client=self.client,
+                ))
+
+            except Exception as e:
+                logger.error(f"REWARD ERROR: {e} for tx_hash: {tx_hash}")
+        
+    reward_hash = hash_from_rewards(reward_writes)
+    validator_updates = self.validator_handler.build_validator_updates()
+    validator_updates_hash = hash_list(validator_updates)
+    self.fingerprint_hashes.append(validator_updates_hash)
+    self.fingerprint_hashes.append(reward_hash)
+    self.fingerprint_hash = hash_list(self.fingerprint_hashes)
+
+    return ResponseFinalizeBlock(validator_updates=validator_updates, tx_results=tx_results, app_hash=self.fingerprint_hash)

--- a/src/xian/methods/info.py
+++ b/src/xian/methods/info.py
@@ -1,0 +1,13 @@
+from cometbft.abci.v1beta1.types_pb2 import ResponseInfo
+from xian.driver_api import (
+    get_latest_block_hash,
+    get_latest_block_height,
+)
+
+def info(self, req) -> ResponseInfo:
+    res = ResponseInfo()
+    res.app_version = self.app_version
+    res.version = req.version
+    res.last_block_height = get_latest_block_height(self.driver)
+    res.last_block_app_hash = get_latest_block_hash(self.driver)
+    return res

--- a/src/xian/methods/init_chain.py
+++ b/src/xian/methods/init_chain.py
@@ -1,0 +1,8 @@
+from cometbft.abci.v1beta3.types_pb2 import ResponseInitChain
+import asyncio
+
+def init_chain(self, req) -> ResponseInitChain:
+    abci_genesis_state = self.genesis["abci_genesis"]
+    asyncio.ensure_future(self.xian.store_genesis_block(abci_genesis_state))
+
+    return ResponseInitChain()

--- a/src/xian/methods/prepare_proposal.py
+++ b/src/xian/methods/prepare_proposal.py
@@ -1,0 +1,5 @@
+from cometbft.abci.v1beta2.types_pb2 import ResponsePrepareProposal
+
+def prepare_proposal(self, req) -> ResponsePrepareProposal:
+    response = ResponsePrepareProposal(txs=req.txs)
+    return response

--- a/src/xian/methods/process_proposal.py
+++ b/src/xian/methods/process_proposal.py
@@ -1,0 +1,6 @@
+from cometbft.abci.v1beta2.types_pb2 import ResponseProcessProposal
+
+def process_proposal(self, req) -> ResponseProcessProposal:
+    response = ResponseProcessProposal()
+    response.status = ResponseProcessProposal.ProposalStatus.ACCEPT
+    return response

--- a/src/xian/methods/query.py
+++ b/src/xian/methods/query.py
@@ -1,0 +1,102 @@
+from cometbft.abci.v1beta1.types_pb2 import ResponseQuery
+from xian.driver_api import (
+    get_value_of_key,
+    get_keys,
+)
+from xian.utils import encode_str
+from abci.application import (
+    OkCode, 
+    ErrorCode
+)
+from contracting.stdlib.bridge.decimal import ContractingDecimal
+from contracting.compilation import parser
+import logging
+import json
+
+logger = logging.getLogger(__name__)
+
+def query(self, req) -> ResponseQuery:
+    """
+    Query the application state
+    Request Ex. http://localhost:26657/abci_query?path="path"
+    (Yes you need to quote the path)
+    """
+
+    result = None
+    type_of_data = "None"
+    key = ""
+
+    try:
+        request_path = req.path
+        path_parts = [part for part in request_path.split("/") if part]
+
+        # http://localhost:26657/abci_query?path="/get/currency.balances:c93dee52d7dc6cc43af44007c3b1dae5b730ccf18a9e6fb43521f8e4064561e6"
+        if path_parts and path_parts[0] == "get":
+            result = get_value_of_key(path_parts[1], self.driver)
+            key = path_parts[1]
+
+        # http://localhost:26657/abci_query?path="/keys/currency.balances" BLOCK SERVICE MODE ONLY
+        if self.block_service_mode:
+            if path_parts[0] == "keys":
+                result = get_keys(self.driver, path_parts[1])
+
+        # http://localhost:26657/abci_query?path="/health"
+        if path_parts[0] == "health":
+            result = "OK"
+
+        # http://localhost:26657/abci_query?path="/get_next_nonce/ddd326fddb5d1677595311f298b744a4e9f415b577ac179a6afbf38483dc0791"
+        if path_parts[0] == "get_next_nonce":
+            result = self.nonce_storage.get_next_nonce(sender=path_parts[1])
+
+        # http://localhost:26657/abci_query?path="/contract/con_some_contract"
+        if path_parts[0] == "contract":
+            self.client.raw_driver.clear_pending_state()
+            result = self.client.raw_driver.get_contract(path_parts[1])
+
+        # http://localhost:26657/abci_query?path="/contract_methods/con_some_contract"
+        if path_parts[0] == "contract_methods":
+            self.client.raw_driver.clear_pending_state()
+            
+            contract_code = self.client.raw_driver.get_contract(path_parts[1])
+            if contract_code is not None:
+                funcs = parser.methods_for_contract(contract_code)
+                result = {"methods": funcs}
+
+        # http://localhost:26657/abci_query?path="/contract_vars/con_some_contract"
+        if path_parts[0] == "contract_vars":
+            self.client.raw_driver.clear_pending_state()
+
+            contract_code = self.client.raw_driver.get_contract(path_parts[1])
+            if contract_code is not None:
+                result = parser.variables_for_contract(contract_code)
+
+        # http://localhost:26657/abci_query?path="/ping"
+        if path_parts[0] == "ping":
+            result = {'status': 'online'}
+
+        if result:
+            if isinstance(result, str):
+                v = encode_str(result)
+                type_of_data = "str"
+            elif isinstance(result, int):
+                v = encode_str(str(result))
+                type_of_data = "int"
+            elif isinstance(result, float) or isinstance(result, ContractingDecimal):
+                v = encode_str(str(result))
+                type_of_data = "decimal"
+            elif isinstance(result, dict) or isinstance(result, list):
+                v = encode_str(json.dumps(result))
+                type_of_data = "str"
+            else:
+                v = encode_str(str(result))
+                type_of_data = "str"
+        else:
+            # If no result, return a byte string representing None
+            v = b"\x00"
+            type_of_data = "None"
+
+    except Exception as e:
+        logger.error(f"QUERY ERROR: {e}")
+        return ResponseQuery(code=ErrorCode, log=f"QUERY ERROR")
+
+    return ResponseQuery(code=OkCode, value=v, info=type_of_data, key=encode_str(key))

--- a/src/xian/xian_abci.py
+++ b/src/xian/xian_abci.py
@@ -1,68 +1,33 @@
-import asyncio
-import json
-import time
 import logging
 import os
-
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
-from cometbft.abci.v1beta1.types_pb2 import (
-    ResponseInfo,
-    ResponseQuery,
-    ResponseEcho,
-)
-from cometbft.abci.v1beta3.types_pb2 import (
-    ResponseInitChain,
-    ResponseFinalizeBlock,
-    ExecTxResult,    
-    ResponseCommit,
-    ResponseCheckTx,
-)
-
-from cometbft.abci.v1beta2.types_pb2 import (
-    ResponsePrepareProposal,
-    ResponseProcessProposal,
-)
-
-
-from xian.validators import ValidatorHandler
-
 from abci.server import ABCIServer
-from abci.application import BaseApplication, OkCode, ErrorCode
-from xian.driver_api import (
-    get_latest_block_hash,
-    set_latest_block_hash,
-    get_latest_block_height,
-    set_latest_block_height,
-    get_value_of_key,
-    get_keys,
-)
-from xian.rewards import (
-    distribute_rewards,
-    distribute_static_rewards,)
-from xian.utils import (
-    encode_str,
-    decode_transaction_bytes,
-    unpack_transaction,
-    get_nanotime_from_block_time,
-    convert_binary_to_hex,
-    load_tendermint_config,
-    stringify_decimals,
-    load_genesis_data,
-    hash_from_rewards,
-    verify,
-    hash_list,
-    hash_from_rewards
-)
+from abci.application import BaseApplication
 
-from xian.storage import NonceStorage
 from contracting.client import ContractingClient
 from contracting.db.driver import (
     ContractDriver,
 )
-from contracting.stdlib.bridge.decimal import ContractingDecimal
-from contracting.compilation import parser
+
+from xian.methods.init_chain import init_chain
+from xian.methods.echo import echo
+from xian.methods.info import info
+from xian.methods.check_tx import check_tx
+from xian.methods.finalize_block import finalize_block
+from xian.methods.commit import commit
+from xian.methods.process_proposal import process_proposal
+from xian.methods.prepare_proposal import prepare_proposal
+from xian.methods.query import query
+
+from xian.validators import ValidatorHandler
+from xian.storage import NonceStorage
 from xian.node_base import Node
+from xian.utils import (
+    load_tendermint_config,
+    load_genesis_data,
+)
+
 # Logging
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO
@@ -93,6 +58,7 @@ class Xian(BaseApplication):
         self.block_service_mode = self.config.get("block_service_mode", True)
         self.pruning_enabled = self.config.get("pruning_enabled", False) 
         self.blocks_to_keep = self.config.get("blocks_to_keep", 100000) # If pruning is enabled, this is the number of blocks to keep history for
+        self.app_version = 1
 
         if self.chain_id is None:
             raise ValueError("No value set for 'chain_id' in genesis block")
@@ -100,264 +66,77 @@ class Xian(BaseApplication):
         if self.genesis.get("abci_genesis", None) is None:
             raise ValueError("No value set for 'abci_genesis' in Tendermint genesis.json")
 
-        # current_block_meta :
-        # schema :
-        # {
-        #    nanos: int
-        #    height: int
-        #    hash: str
-        # }
-        # set in begin_block
-        # used as environment for each tx in block
-        # unset at end_block / commit
-
-        # benchmark metrics
-        self.tx_count = 0
-        self.start_time = time.time()
-
         self.enable_tx_fee = True
         self.static_rewards = False
         self.static_rewards_amount_foundation = 1
         self.static_rewards_amount_validators = 1
         self.current_block_rewards = {}
     
-    def echo(self, req) -> ResponseEcho:
-        r = ResponseEcho()
-        r.version = req.version
-        r.last_block_height = get_latest_block_height(self.driver)
-        r.last_block_app_hash = get_latest_block_hash(self.driver)
-        return r
-
-    def info(self, req) -> ResponseInfo:
+    def echo(self, req):
         """
-        Called every time the application starts
+        Echo a string to test an ABCI client/server implementation
         """
-        res = ResponseInfo()
-        res.version = req.version
-        res.last_block_height = get_latest_block_height(self.driver)
-        res.last_block_app_hash = get_latest_block_hash(self.driver)
+        res = echo(self, req)
         return res
 
-    def init_chain(self, req) -> ResponseInitChain:
-        """Called the first time the application starts; when block_height is 0"""
-        abci_genesis_state = self.genesis["abci_genesis"]
-        asyncio.ensure_future(self.xian.store_genesis_block(abci_genesis_state))
-
-        return ResponseInitChain()
-
-    def check_tx(self, raw_tx) -> ResponseCheckTx:
+    def info(self, req):
         """
-        Validate the Tx before entry into the mempool
-        Checks the txs are submitted in order 1,2,3...
-        If not an order, a non-zero code is returned and the tx
-        will be dropped.
+        Called every time the application starts
+        Return information about the application state.
         """
-        try:
-            tx = decode_transaction_bytes(raw_tx)
-            self.xian.validate_transaction(tx)
-            sender, signature, payload = unpack_transaction(tx)
-            if not verify(sender, payload, signature):
-                return ResponseCheckTx(code=ErrorCode)
-            payload_json = json.loads(payload)
-            if payload_json["chain_id"] != self.chain_id:
-                return ResponseCheckTx(code=ErrorCode)
-            return ResponseCheckTx(code=OkCode)
-        except Exception as e:
-            logger.error(e)
-            return ResponseCheckTx(code=ErrorCode, info=f"ERROR: {e}")
+        res = info(self, req)
+        return res
 
-    def finalize_block(self, req) -> ResponseFinalizeBlock:
+    def init_chain(self, req):
+        """Called once upon genesis."""
+        resp = init_chain(self, req)
+        return resp
+
+    def check_tx(self, raw_tx):
         """
-        Called during the consensus process.
-
-        CometBFT, ABCI 2.0 coalesces the BeginBlock, DeliverTx and EndBlock messages into a single message called FinalizeBlock.
+        Technically optional - not involved in processing blocks.
+        Guardian of the mempool: every node runs CheckTx before letting a transaction into its local mempool.
+        The transaction may come from an external user or another node
         """
-        nanos = get_nanotime_from_block_time(req.time)
-        hash = convert_binary_to_hex(req.hash)
-        height = req.height
-        tx_results = []
-        reward_writes = []
+        res = check_tx(self, raw_tx)
+        return res
 
-        self.current_block_meta = {
-            "nanos": nanos,
-            "height": height,
-            "hash": hash,
-        }   
+    def finalize_block(self, req):
+        """
+        Contains the fields of the newly decided block.
+        This method is equivalent to the call sequence BeginBlock, [DeliverTx], and EndBlock in the previous version of ABCI.
+        """
+        res = finalize_block(self, req)
+        return res
 
-        for tx in req.txs: 
-            try:
-                tx = decode_transaction_bytes(tx)
-                sender, signature, payload = unpack_transaction(tx)
-                if not verify(sender, payload, signature):
-                    raise Exception("Invalid Signature") # Not really needed, because check_tx should catch this first, but just in case
-                # Attach metadata to the transaction
-                tx["b_meta"] = self.current_block_meta
-                result = self.xian.tx_processor.process_tx(tx, enabled_fees=self.enable_tx_fee)
-
-                if self.enable_tx_fee:
-                    self.current_block_rewards[tx['b_meta']['hash']] = {
-                        "amount": result["stamp_rewards_amount"],
-                        "contract": result["stamp_rewards_contract"]
-                    }
-
-                self.xian.set_nonce(tx)
-                tx_hash = result["tx_result"]["hash"]
-                self.fingerprint_hashes.append(tx_hash)
-                parsed_tx_result = json.dumps(stringify_decimals(result["tx_result"]))
-                logger.debug(f"parsed tx result : {parsed_tx_result}")
-                tx_results.append(ExecTxResult(code=result["tx_result"]["status"],data=encode_str(parsed_tx_result),gas_used=result["stamp_rewards_amount"]))
-            except Exception as e:
-                # Normally this cannot happen, but if it does, we need to catch it
-                logger.error(f"Fatal ERROR: {e}")
-                tx_results.append(ExecTxResult(code=ErrorCode, data=encode_str(f"ERROR: {e}"), gas_used=0))
-
-        if self.static_rewards:
-            try:
-                reward_writes.append(distribute_static_rewards(
-                    driver=self.driver,
-                    foundation_reward=self.static_rewards_amount_foundation,
-                    master_reward=self.static_rewards_amount_validators,
-                ))
-            except Exception as e:
-                logger.error(f"STATIC REWARD ERROR: {e} for block")
-
-        if self.current_block_rewards:
-            for tx_hash, reward in self.current_block_rewards.items():
-                try:
-                    reward_writes.append(distribute_rewards(
-                        stamp_rewards_amount=reward["amount"],
-                        stamp_rewards_contract=reward["contract"],
-                        driver=self.driver,
-                        client=self.client,
-                    ))
-
-                except Exception as e:
-                    logger.error(f"REWARD ERROR: {e} for tx_hash: {tx_hash}")
-           
-        reward_hash = hash_from_rewards(reward_writes)
-        validator_updates = self.validator_handler.build_validator_updates()
-        validator_updates_hash = hash_list(validator_updates)
-        self.fingerprint_hashes.append(validator_updates_hash)
-        self.fingerprint_hashes.append(reward_hash)
-        self.fingerprint_hash = hash_list(self.fingerprint_hashes)
-
-        return ResponseFinalizeBlock(validator_updates=validator_updates, tx_results=tx_results, app_hash=self.fingerprint_hash)
-
-    def commit(self) -> ResponseCommit:
-        # commit block to filesystem db
-        set_latest_block_hash(self.fingerprint_hash, self.driver)
-        set_latest_block_height(self.current_block_meta["height"], self.driver)
-
-        self.driver.hard_apply(str(self.current_block_meta["nanos"]))
-
-        # unset current_block_meta & cleanup
-        self.current_block_meta = None
-        self.fingerprint_hashes = []
-        self.fingerprint_hash = None
-        self.current_block_rewards = {}
-
-        retain_height = 0 
-        if self.pruning_enabled:
-            if self.current_block_meta["height"] > self.blocks_to_keep:
-                retain_height = self.current_block_meta["height"] - self.blocks_to_keep
-
-        return ResponseCommit(retain_height=retain_height)
+    def commit(self):
+        """
+        Signal the Application to persist the application state. Application is expected to persist its state at the end of this call, before calling ResponseCommit.
+        """
+        res = commit(self)
+        return res
     
-    def process_proposal(self, req) -> ResponseProcessProposal:
-        response = ResponseProcessProposal()
-        response.status = ResponseProcessProposal.ProposalStatus.ACCEPT
-        return response
+    def process_proposal(self, req):
+        """
+        Contains all information on the proposed block needed to fully execute it.
+        """
+        res = process_proposal(self, req)
+        return res
     
-    def prepare_proposal(self, req) -> ResponsePrepareProposal:
-        response = ResponsePrepareProposal(txs=req.txs)
-        return response
-
-    # TODO: Probably best to use FastAPI here and add proper error handling
-    def query(self, req) -> ResponseQuery:
+    def prepare_proposal(self, req):
+        """
+        RequestPrepareProposal contains a preliminary set of transactions txs that CometBFT retrieved from the mempool, called raw proposal. The Application can modify this set and return a modified set of transactions via ResponsePrepareProposal.txs .
+        """
+        res = prepare_proposal(self, req)
+        return res
+    
+    def query(self, req):
         """
         Query the application state
         Request Ex. http://localhost:26657/abci_query?path="path"
-        (Yes you need to quote the path)
         """
-
-        result = None
-        type_of_data = "None"
-        key = ""
-
-        try:
-            request_path = req.path
-            path_parts = [part for part in request_path.split("/") if part]
-
-            # http://localhost:26657/abci_query?path="/get/currency.balances:c93dee52d7dc6cc43af44007c3b1dae5b730ccf18a9e6fb43521f8e4064561e6"
-            if path_parts and path_parts[0] == "get":
-                result = get_value_of_key(path_parts[1], self.driver)
-                key = path_parts[1]
-
-            # http://localhost:26657/abci_query?path="/keys/currency.balances" BLOCK SERVICE MODE ONLY
-            if self.block_service_mode:
-                if path_parts[0] == "keys":
-                    result = get_keys(self.driver, path_parts[1])
-
-            # http://localhost:26657/abci_query?path="/health"
-            if path_parts[0] == "health":
-                result = "OK"
-
-            # http://localhost:26657/abci_query?path="/get_next_nonce/ddd326fddb5d1677595311f298b744a4e9f415b577ac179a6afbf38483dc0791"
-            if path_parts[0] == "get_next_nonce":
-                result = self.nonce_storage.get_next_nonce(sender=path_parts[1])
-
-            # http://localhost:26657/abci_query?path="/contract/con_some_contract"
-            if path_parts[0] == "contract":
-                self.client.raw_driver.clear_pending_state()
-                result = self.client.raw_driver.get_contract(path_parts[1])
-
-            # http://localhost:26657/abci_query?path="/contract_methods/con_some_contract"
-            if path_parts[0] == "contract_methods":
-                self.client.raw_driver.clear_pending_state()
-                
-                contract_code = self.client.raw_driver.get_contract(path_parts[1])
-                if contract_code is not None:
-                    funcs = parser.methods_for_contract(contract_code)
-                    result = {"methods": funcs}
-
-            # http://localhost:26657/abci_query?path="/contract_vars/con_some_contract"
-            if path_parts[0] == "contract_vars":
-                self.client.raw_driver.clear_pending_state()
-
-                contract_code = self.client.raw_driver.get_contract(path_parts[1])
-                if contract_code is not None:
-                    result = parser.variables_for_contract(contract_code)
-
-            # http://localhost:26657/abci_query?path="/ping"
-            if path_parts[0] == "ping":
-                result = {'status': 'online'}
-
-            if result:
-                if isinstance(result, str):
-                    v = encode_str(result)
-                    type_of_data = "str"
-                elif isinstance(result, int):
-                    v = encode_str(str(result))
-                    type_of_data = "int"
-                elif isinstance(result, float) or isinstance(result, ContractingDecimal):
-                    v = encode_str(str(result))
-                    type_of_data = "decimal"
-                elif isinstance(result, dict) or isinstance(result, list):
-                    v = encode_str(json.dumps(result))
-                    type_of_data = "str"
-                else:
-                    v = encode_str(str(result))
-                    type_of_data = "str"
-            else:
-                # If no result, return a byte string representing None
-                v = b"\x00"
-                type_of_data = "None"
-
-        except Exception as e:
-            logger.error(f"QUERY ERROR: {e}")
-            return ResponseQuery(code=ErrorCode, log=f"QUERY ERROR")
-
-        return ResponseQuery(code=OkCode, value=v, info=type_of_data, key=encode_str(key))
+        res = query(self, req)
+        return res
 
 
 def main():


### PR DESCRIPTION
In prep for the Upgrade Handler of the chain I put all abci methods in their own files.
Lets say we run a chain from block 0 - 1000 and then we change logic in finalize_block till 2k that works fine for one node.

If you resync one from scratch with code changes from block 1000-2000, the first 1k blocks will all fail to sync because the resulting hashes are wrong when replaying txs.

so the plan for the upgrade handler is that we can use importlib (a built in module) with its reload function. this will allow us to reload a method file after we git pulled for example at block 1001  without needing to restart the app.