### PR TITLE
Rm compiled code from tx return schema

### DIFF
--- a/src/xian/tools/export_state.py
+++ b/src/xian/tools/export_state.py
@@ -69,10 +69,11 @@ def build_genesis_block(founder_sk: str, contract_state: dict, run_state: dict):
     genesis_block['genesis'] = sorted(genesis_block['genesis'], key=lambda d: d['key'])
     genesis_block['nonces'] = nonces
 
-    print('Signing state changes...')
-    founders_wallet = Wallet(seed=bytes.fromhex(founder_sk))
-    genesis_block['origin']['sender'] = founders_wallet.public_key
-    genesis_block['origin']['signature'] = founders_wallet.sign_msg(hash_genesis_block_state_changes(genesis_block['genesis']))
+    if founder_sk:
+        print('Signing state changes...')
+        founders_wallet = Wallet(seed=bytes.fromhex(founder_sk))
+        genesis_block['origin']['sender'] = founders_wallet.public_key
+        genesis_block['origin']['signature'] = founders_wallet.sign_msg(hash_genesis_block_state_changes(genesis_block['genesis']))
     return genesis_block
 
 
@@ -93,8 +94,8 @@ def main(
 
 if __name__ == '__main__':
     parser = ArgumentParser()
-    parser.add_argument('-k', '--key', type=str, required=True)
-    parser.add_argument('--output-path', type=str, required=True)
+    parser.add_argument('-k', '--key', type=str, required=False)
+    parser.add_argument('--output-path', type=str, required=False)
     args = parser.parse_args()
-    output_path = Path(args.output_path)
+    output_path = Path(args.output_path) if args.output_path is not None else Path("./")
     main(args.key, output_path)

--- a/src/xian/tools/export_state.py
+++ b/src/xian/tools/export_state.py
@@ -97,5 +97,5 @@ if __name__ == '__main__':
     parser.add_argument('-k', '--key', type=str, required=False)
     parser.add_argument('--output-path', type=str, required=False)
     args = parser.parse_args()
-    output_path = Path(args.output_path) if args.output_path is not None else Path("./")
+    output_path = Path(args.output_path) if args.output_path is not None else Path.cwd()
     main(args.key, output_path)

--- a/src/xian/utils.py
+++ b/src/xian/utils.py
@@ -401,11 +401,11 @@ def validate_transaction(client, nonce_storage, tx):
         check_contract_name(contract, func, name)
 
 
-def recompile_contract_from_source(s: dict):
-        code = compile(s["value"], '', "exec")
-        serialized_code = marshal.dumps(code)
-        hexadecimal_string = binascii.hexlify(serialized_code).decode()
-        return hexadecimal_string
+def compile_contract_from_source(s: dict):
+    code = compile(s["value"], '', "exec")
+    serialized_code = marshal.dumps(code)
+    hexadecimal_string = binascii.hexlify(serialized_code).decode()
+    return hexadecimal_string
 
 
 def apply_state_changes_from_block(client, nonce_storage, block):
@@ -419,10 +419,11 @@ def apply_state_changes_from_block(client, nonce_storage, block):
         parts = s["key"].split(".")
 
         if parts[1] == "__code__":
-            contract_key = f"{parts[0]}.__compiled__"
-            print(f"processing {contract_key}")
+            compiled_contract_key = f"{parts[0]}.__compiled__"
+            print(f"processing {compiled_contract_key}")
             # the encoded contract data from genesis was invalid, so we recompile it.
-            state_changes[i + 1]["value"]["__bytes__"] = recompile_contract_from_source(s)
+            compiled_code = compile_contract_from_source(s)
+            client.raw_driver.set(compiled_contract_key, compiled_code)
         if type(s['value']) is dict:
             s['value'] = convert_dict(s['value'])
 


### PR DESCRIPTION
- removed __compiled__ bytecode from tx return schema
- export_state now needs no args to run (will not sign block if no key is provided)