### PR TITLE
Block service stuff

### DIFF
--- a/src/xian/methods/query.py
+++ b/src/xian/methods/query.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import ast
 import re
@@ -19,7 +20,6 @@ from pyflakes.reporter import Reporter
 from urllib.parse import unquote
 
 from io import StringIO
-import base64
 
 
 def query(self, req) -> ResponseQuery:
@@ -33,6 +33,7 @@ def query(self, req) -> ResponseQuery:
     key = ""
 
     try:
+        logger.debug(req.path)
         request_path = req.path
         path_parts = [part for part in request_path.split("/") if part]
 
@@ -41,18 +42,49 @@ def query(self, req) -> ResponseQuery:
             result = self.client.raw_driver.get(path_parts[1])
             key = path_parts[1]
 
-        # http://localhost:26657/abci_query?path="/keys/currency.balances" BLOCK SERVICE MODE ONLY
+        # http://localhost:26657/abci_query?path="/health"
+        elif path_parts[0] == "health":
+            result = "OK"
+
+        # http://localhost:26657/abci_query?path="/get_next_nonce/ddd326fddb5d1677595311f298b744a4e9f415b577ac179a6afbf38483dc0791"
+        elif path_parts[0] == "get_next_nonce":
+            result = self.nonce_storage.get_next_nonce(sender=path_parts[1])
+
+        # http://localhost:26657/abci_query?path="/contract/con_some_contract"
+        elif path_parts[0] == "contract":
+            result = self.client.raw_driver.get_contract(path_parts[1])
+
+        # http://localhost:26657/abci_query?path="/contract_methods/con_some_contract"
+        elif path_parts[0] == "contract_methods":
+            contract_code = self.client.raw_driver.get_contract(path_parts[1])
+            if contract_code is not None:
+                funcs = parser.methods_for_contract(contract_code)
+                result = {"methods": funcs}
+
+        # http://localhost:26657/abci_query?path="/contract_vars/con_some_contract"
+        elif path_parts[0] == "contract_vars":
+            contract_code = self.client.raw_driver.get_contract(path_parts[1])
+            if contract_code is not None:
+                result = parser.variables_for_contract(contract_code)
+
+        # http://localhost:26657/abci_query?path="/ping"
+        elif path_parts[0] == "ping":
+            result = {'status': 'online'}
+
+        # BLOCK SERVICE MODE
         if self.block_service_mode:
+            # http://localhost:26657/abci_query?path="/keys/currency.balances"
             if path_parts[0] == "keys":
                 list_of_keys = self.client.raw_driver.keys(prefix=path_parts[1])
                 result = [key.split(":")[1] for key in list_of_keys]
                 key = path_parts[1]
 
-            if path_parts[0] == "contracts":
+            # http://localhost:26657/abci_query?path="/contracts"
+            elif path_parts[0] == "contracts":
                 result = self.client.raw_driver.get_contract_files()
 
             # http://localhost:26657/abci_query?path="/lint/<code>"
-            if path_parts[0] == "lint":
+            elif path_parts[0] == "lint":
                 try:
                     code = base64.b64decode(path_parts[1]).decode("utf-8")
                     code = unquote(code)
@@ -64,7 +96,7 @@ def query(self, req) -> ResponseQuery:
                     check(code, "<string>", reporter)
                     stdout_output = stdout.getvalue()
                     stderr_output = stderr.getvalue()
-                    
+
                     # Contracting linting
                     try:
                         linter = Linter()
@@ -78,54 +110,23 @@ def query(self, req) -> ResponseQuery:
                                 message = re.search(r"Line \d+: (.+)", violation).group(1)
                                 formatted_violation_output = f"<string>:{line}:0: {message}\n"
                                 formatted_new_linter_output += formatted_violation_output
-                    except Exception as e:
+                    except:
                         formatted_new_linter_output = ""
-                    
 
                     # Combine stderr output
                     combined_stderr_output = f"{stderr_output}{formatted_new_linter_output}"
 
                     result = {"stdout": stdout_output, "stderr": combined_stderr_output}
-                except Exception as e:
+                except:
                     result = {"stdout": "", "stderr": ""}
 
-        # http://localhost:26657/abci_query?path="/estimate_stamps/<encoded_txn>" BLOCK SERVICE MODE ONLY
-        if self.block_service_mode:
-            if path_parts[0] == "estimate_stamps":
+            # http://localhost:26657/abci_query?path="/calculate_stamps/<encoded_txn>"
+            elif path_parts[0] == "calculate_stamps":
                 raw_tx = path_parts[1]
                 byte_data = bytes.fromhex(raw_tx)
                 tx_hex = byte_data.decode("utf-8")
                 tx = json.loads(tx_hex)
-                result = self.stamp_estimator.execute(tx)
-
-        # http://localhost:26657/abci_query?path="/health"
-        if path_parts[0] == "health":
-            result = "OK"
-
-        # http://localhost:26657/abci_query?path="/get_next_nonce/ddd326fddb5d1677595311f298b744a4e9f415b577ac179a6afbf38483dc0791"
-        if path_parts[0] == "get_next_nonce":
-            result = self.nonce_storage.get_next_nonce(sender=path_parts[1])
-
-        # http://localhost:26657/abci_query?path="/contract/con_some_contract"
-        if path_parts[0] == "contract":
-            result = self.client.raw_driver.get_contract(path_parts[1])
-
-        # http://localhost:26657/abci_query?path="/contract_methods/con_some_contract"
-        if path_parts[0] == "contract_methods":
-            contract_code = self.client.raw_driver.get_contract(path_parts[1])
-            if contract_code is not None:
-                funcs = parser.methods_for_contract(contract_code)
-                result = {"methods": funcs}
-
-        # http://localhost:26657/abci_query?path="/contract_vars/con_some_contract"
-        if path_parts[0] == "contract_vars":
-            contract_code = self.client.raw_driver.get_contract(path_parts[1])
-            if contract_code is not None:
-                result = parser.variables_for_contract(contract_code)
-
-        # http://localhost:26657/abci_query?path="/ping"
-        if path_parts[0] == "ping":
-            result = {'status': 'online'}
+                result = self.stamp_calculator.execute(tx)
 
         if result is not None:
             if isinstance(result, str):
@@ -144,14 +145,12 @@ def query(self, req) -> ResponseQuery:
                 v = encode_str(str(result))
                 type_of_data = "str"
         else:
-            # If no result, return a byte string representing None
-            v = b"\x00"
-            type_of_data = "None"
+            error = f'Unknown query path: {path_parts[0]}'
+            logger.error(error)
+            return ResponseQuery(code=ErrorCode, value=b"\x00", info=None, log=error)
 
     except Exception as err:
-        import traceback
-        traceback.print_exc()
-        logger.error(f"QUERY ERROR: {err}")
-        return ResponseQuery(code=ErrorCode, log=f"QUERY ERROR")
+        logger.error(err)
+        return ResponseQuery(code=ErrorCode, log=err)
 
     return ResponseQuery(code=OkCode, value=v, info=type_of_data, key=encode_str(key))

--- a/src/xian/services/stamp_estimator.py
+++ b/src/xian/services/stamp_estimator.py
@@ -6,7 +6,7 @@ from xian.utils import format_dictionary, stringify_decimals
 import secrets
 
 
-class StampEstimator:
+class StampCalculator:
     def __init__(self):
         self.executor = Executor(metering=False, bypass_balance_amount=True, bypass_cache=True)
 

--- a/src/xian/tools/configure.py
+++ b/src/xian/tools/configure.py
@@ -103,11 +103,11 @@ class Configure:
             default=True
         )
         parser.add_argument(
-            '--is-service-node',
-             type=bool,
-             help='If the node is a service node',
-             required=False,
-             default=False
+            '--service-node',
+            type=bool,
+            help='If the node is a service node',
+            required=False,
+            default=False
         )
 
         self.args = parser.parse_args()
@@ -134,7 +134,6 @@ class Configure:
             sleep(1)  # wait 1 second before trying again
 
         return None  # or raise an Exception indicating the request ultimately failed
-
     
     def download_and_extract(self, url, target_path):
         # Download the file from the URL
@@ -203,7 +202,6 @@ class Configure:
         if not os.path.exists(self.CONFIG_PATH):
             print('Initialize CometBFT first')
             return
-        
 
         with open(self.CONFIG_PATH, 'r') as f:
             config = toml.load(f)
@@ -222,9 +220,7 @@ class Configure:
             else:
                 print("Failed to get node information after 10 attempts.")
 
-
-        if self.args.is_service_node:
-            config['p2p']['block_service_mode'] = True
+        config['p2p']['block_service_mode'] = self.args.is_service_node
 
         config['proxy_app'] = self.UNIX_SOCKET_PATH
 
@@ -299,7 +295,6 @@ class Configure:
 
             with open(target_path, 'w') as f:
                 f.write(json.dumps(keys, indent=2))
-
 
         if self.args.prometheus:
             config['instrumentation']['prometheus'] = True

--- a/src/xian/xian_abci.py
+++ b/src/xian/xian_abci.py
@@ -25,7 +25,7 @@ from xian.methods import (
 from xian.upgrader import UpgradeHandler
 from xian.validators import ValidatorHandler
 from xian.storage import NonceStorage
-from xian.services.stamp_estimator import StampEstimator
+from xian.services.stamp_estimator import StampCalculator
 from xian.processor import TxProcessor
 from xian.rewards import RewardsHandler
 
@@ -79,8 +79,8 @@ class Xian:
         self.fingerprint_hashes = []
         self.fingerprint_hash = None
         self.chain_id = self.genesis.get("chain_id", None)
-        self.block_service_mode = self.config.get("block_service_mode", False)
-        self.stamp_estimator = StampEstimator() if self.block_service_mode else None
+        self.block_service_mode = self.config["p2p"]["block_service_mode"]
+        self.stamp_calculator = StampCalculator() if self.block_service_mode else None
         self.pruning_enabled = self.config.get("pruning_enabled", False)
         # If pruning is enabled, this is the number of blocks to keep history for
         self.blocks_to_keep = self.config.get("blocks_to_keep", 100000)


### PR DESCRIPTION
- Fixes loading `block_service_mode` from `config.toml`
- Renamed "stamp estimation" to "stamp calculation"
- Better error handling for queries
- Better logging related to queries

### IMPORTANT
- Stamp estimation endpoint changed from `/estimate_stamps/` to `/calculate_stamps/`
- In `configure.py` `--is-service-node` changed to `--service-node` since `--is-service-node` implies the value being TRUE

### TODO
- In `config.toml` after we know in which category `pruning_enabled` and `blocks_to_keep` are, make sure we read it properly from there
- In `configure.py` set `pruning_enabled` and `blocks_to_keep` with default values