### PR TITLE
add chain_id const to environment

### DIFF
--- a/src/xian/methods/finalize_block.py
+++ b/src/xian/methods/finalize_block.py
@@ -32,6 +32,7 @@ async def finalize_block(self, req) -> ResponseFinalizeBlock:
         "nanos": nanos,
         "height": height,
         "hash": hash,
+        "chain_id": self.chain_id,
     }   
 
     for tx in req.txs:

--- a/src/xian/processor.py
+++ b/src/xian/processor.py
@@ -232,6 +232,7 @@ class TxProcessor:
         block_meta = tx["b_meta"]
         nanos = block_meta["nanos"]
         signature = tx['metadata']['signature']
+        chain_id = block_meta["chain_id"]
 
         # Nanos is set at the time of block being processed, and is shared between all txns in a block.
         # TODO : confirm this w/ CometBFT docs.
@@ -239,14 +240,12 @@ class TxProcessor:
         # it's set during the consensus agreement & voting for block between all validators.
 
         return {
-            # TODO: review
             'block_hash': block_meta["hash"],  # hash nanos
             'block_num': block_meta["height"],  # block number
-            # TODO: review
-            # Used for deterministic entropy for random games
             '__input_hash': self.get_timestamp_hash_from_tx(nanos, signature),
             'now': self.get_now_from_nanos(nanos=nanos),
-            'AUXILIARY_SALT': signature
+            'AUXILIARY_SALT': signature,
+            'chain_id': chain_id,
         }
 
     def get_timestamp_hash_from_tx(self, nanos, signature):


### PR DESCRIPTION
## Description

Make `chain_id` available to the contract execution environment, needed for protecting against permit replays.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would require a resync of blockchain state)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change