### PR TITLE
unhackable deterministic tx sequence

### DIFF
--- a/src/xian/methods/prepare_proposal.py
+++ b/src/xian/methods/prepare_proposal.py
@@ -1,6 +1,15 @@
 from cometbft.abci.v1beta2.types_pb2 import ResponsePrepareProposal
+from xian.utils import decode_transaction_bytes, encode_transaction
 
 
 async def prepare_proposal(self, req) -> ResponsePrepareProposal:
-    response = ResponsePrepareProposal(txs=req.txs)
+    decoded_txs = []
+    for tx in req.txs:
+        try:
+            decoded_txs.append(decode_transaction_bytes(tx))
+        except Exception as e:
+            continue
+    decoded_txs = sorted(decoded_txs)
+    txs = [encode_transaction(tx) for tx in decoded_txs]
+    response = ResponsePrepareProposal(txs=txs)
     return response

--- a/src/xian/methods/process_proposal.py
+++ b/src/xian/methods/process_proposal.py
@@ -1,7 +1,15 @@
 from cometbft.abci.v1beta2.types_pb2 import ResponseProcessProposal
-
+from xian.utils import decode_transaction_bytes, encode_transaction
 
 async def process_proposal(self, req) -> ResponseProcessProposal:
     response = ResponseProcessProposal()
+    txs = []
+    for tx in req.txs:
+        try:
+            txs.append(decode_transaction_bytes(tx))
+        except Exception as e:
+            continue
+    if txs != sorted(txs):
+        response.status = ResponseProcessProposal.ProposalStatus.REJECT
     response.status = ResponseProcessProposal.ProposalStatus.ACCEPT
     return response

--- a/src/xian/methods/process_proposal.py
+++ b/src/xian/methods/process_proposal.py
@@ -11,5 +11,6 @@ async def process_proposal(self, req) -> ResponseProcessProposal:
             continue
     if txs != sorted(txs):
         response.status = ResponseProcessProposal.ProposalStatus.REJECT
-    response.status = ResponseProcessProposal.ProposalStatus.ACCEPT
+    else:
+        response.status = ResponseProcessProposal.ProposalStatus.ACCEPT
     return response

--- a/src/xian/utils.py
+++ b/src/xian/utils.py
@@ -122,6 +122,13 @@ def decode_transaction_bytes(raw):
     tx_json = json.loads(tx_str)
     return tx_json
 
+def encode_transaction(tx):
+    tx_str = json.dumps(tx)
+    tx_bytes = tx_str.encode("utf-8")
+    tx_hex = tx_bytes.hex()
+    tx_encoded_bytes = tx_hex.encode("utf-8")
+    return tx_encoded_bytes
+
 
 def unpack_transaction(tx):
     timestamp = tx["metadata"].get("timestamp", None)


### PR DESCRIPTION
The sorted() function in Python is deterministic. This means that given the same input, sorted() will always produce the same output. 

## Description

At the moment the block proposer can change the sequence in which transactions go through. But this is not wanted for many people.

## Type of change

All transactions get sorted before proposing and when other nodes process the proposal it checks if its sorted right. If its not sorted right it will be rejected

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.