### PR TITLE
State events

### DIFF
--- a/src/xian/methods/finalize_block.py
+++ b/src/xian/methods/finalize_block.py
@@ -1,5 +1,4 @@
 import json
-import asyncio
 
 from cometbft.abci.v1beta2.types_pb2 import Event, EventAttribute
 from cometbft.abci.v1beta3.types_pb2 import (


### PR DESCRIPTION
## Description

This introduces a custom websocket event for state changes.

Listen to events with:
```
wscat -c ws://127.0.0.1:26657/websocket
```

Then enter:
```
{"jsonrpc": "2.0","method": "subscribe","id": 0,"params": {"query": "tm.event='Tx' AND StateChange.currency_balances__b6504cf056e264a4c1932d5de6893d110db5459ab4f742eb415d98ed989bb98d EXISTS"}}
```

This will listen to currency balance changes for address `b6504cf056e264a4c1932d5de6893d110db5459ab4f742eb415d98ed989bb98d`.
Unfortunately we need to replace `.` with `_` and `:` with `__` in the state string since these are reserved


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [x] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change