### PR TITLE
Remove second .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ contracting
 lamden
 /xian_venv
 cometbft
+priv_validator_key.json
+

--- a/src/xian/tools/.gitignore
+++ b/src/xian/tools/.gitignore
@@ -1,1 +1,0 @@
-priv_validator_key.json


### PR DESCRIPTION
## Description

Remove the doubled .gitignore file and move `priv_validator_key.json` into main one

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change