### PR TITLE
use faster cpp backend for protobuf

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir =
 include_package_data = true
 python_requires = ~=3.11.0
 install_requires =
-    protobuf == 4.23.4
+    protobuf == 3.20.3
     colorlog >= 3.1.4
     certifi >= 2022.12.7
     pyflakes

--- a/src/xian/tools/cometbft_debug.py
+++ b/src/xian/tools/cometbft_debug.py
@@ -9,8 +9,6 @@ import json
 import datetime
 import warnings
 
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
-
 TX_INDEX_PATH = Path().home().joinpath(".cometbft/data/tx_index.db")
 STATE_PATH = Path().home().joinpath(".cometbft/data/state.db")
 BLOCKSTORE_PATH = Path().home().joinpath(".cometbft/data/blockstore.db")

--- a/src/xian/xian_abci.py
+++ b/src/xian/xian_abci.py
@@ -6,8 +6,6 @@ import asyncio
 
 from xian.constants import Constants
 
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
-
 from loguru import logger
 from datetime import timedelta
 from abci.server import ABCIServer

--- a/tests/test_abci_handling.py
+++ b/tests/test_abci_handling.py
@@ -45,8 +45,6 @@ from fixtures.test_constants import TestConstants
 # Disable any kind of logging
 logging.disable(logging.CRITICAL)
 
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
-
 async def deserialize(raw: bytes) -> Response:
     try:
         resp = next(read_messages(BytesIO(raw), Response))

--- a/tests/test_check_tx.py
+++ b/tests/test_check_tx.py
@@ -24,8 +24,6 @@ from fixtures.test_constants import TestConstants
 # Disable any kind of logging
 logging.disable(logging.CRITICAL)
 
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
-
 async def deserialize(raw: bytes) -> Response:
     try:
         resp = next(read_messages(BytesIO(raw), Response))

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -22,8 +22,6 @@ from fixtures.test_constants import TestConstants
 # Disable any kind of logging
 logging.disable(logging.CRITICAL)
 
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
-
 async def deserialize(raw: bytes) -> Response:
     try:
         resp = next(read_messages(BytesIO(raw), Response))

--- a/tests/test_finalize_block.py
+++ b/tests/test_finalize_block.py
@@ -24,8 +24,6 @@ from cometbft.abci.v1beta3.types_pb2 import (
 # Disable any kind of logging
 logging.disable(logging.CRITICAL)
 
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
-
 async def deserialize(raw: bytes) -> Response:
     try:
         resp = next(read_messages(BytesIO(raw), Response))

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -24,8 +24,6 @@ from cometbft.abci.v1beta1.types_pb2 import ResponseInfo
 # Disable any kind of logging
 logging.disable(logging.CRITICAL)
 
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
-
 async def deserialize(raw: bytes) -> Response:
     try:
         resp = next(read_messages(BytesIO(raw), Response))

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -23,8 +23,6 @@ import json
 # Disable any kind of logging
 logging.disable(logging.CRITICAL)
 
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
-
 
 async def deserialize(raw: bytes) -> Response:
     try:


### PR DESCRIPTION
## Description

removes the need for this
os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [x] I have added tests to prove that this change works
- [x] All existing tests pass after this change