### PR TITLE
CORE - verify tx payload str

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     loguru
     urwid
     asyncpg
+    parameterized
 
 [options.packages.find]
 where = src

--- a/src/xian/methods/check_tx.py
+++ b/src/xian/methods/check_tx.py
@@ -14,10 +14,10 @@ import json
 
 async def check_tx(self, raw_tx) -> ResponseCheckTx:
     try:
-        tx = decode_transaction_bytes(raw_tx)
+        tx, payload_str = decode_transaction_bytes(raw_tx)
         validate_transaction(self.client,self.nonce_storage,tx)
         sender, signature, payload = unpack_transaction(tx)
-        if not verify(sender, payload, signature):
+        if not verify(sender, payload_str, signature):
             return ResponseCheckTx(code=c.ErrorCode, log="Bad signature")
         payload_json = json.loads(payload)
         if payload_json["chain_id"] != self.chain_id:

--- a/src/xian/methods/finalize_block.py
+++ b/src/xian/methods/finalize_block.py
@@ -45,7 +45,11 @@ async def finalize_block(self, req) -> ResponseFinalizeBlock:
     }
 
     for tx_bytes in req.txs:
-        tx, payload_str = decode_transaction_bytes(tx_bytes)
+        try:
+            tx, payload_str = decode_transaction_bytes(tx_bytes)
+        except Exception as e:
+            logger.error(f"Error decoding transaction: {e}")
+            continue
 
         # Attach metadata to the transaction
         tx["b_meta"] = self.current_block_meta

--- a/src/xian/methods/finalize_block.py
+++ b/src/xian/methods/finalize_block.py
@@ -45,13 +45,7 @@ async def finalize_block(self, req) -> ResponseFinalizeBlock:
     }
 
     for tx_bytes in req.txs:
-        tx = decode_transaction_bytes(tx_bytes)
-        sender, signature, payload = unpack_transaction(tx)
-
-        if not verify(sender, payload, signature):
-            # Not really needed, because check_tx should catch this first, but just in case
-            # Skip this transaction
-            continue
+        tx, payload_str = decode_transaction_bytes(tx_bytes)
 
         # Attach metadata to the transaction
         tx["b_meta"] = self.current_block_meta

--- a/src/xian/utils/encoding.py
+++ b/src/xian/utils/encoding.py
@@ -4,6 +4,7 @@ import hashlib
 from typing import Tuple
 from contracting.stdlib.bridge.decimal import ContractingDecimal
 from contracting.stdlib.bridge.time import Datetime
+from loguru import logger
 import decimal
 
 
@@ -30,30 +31,43 @@ def encode_transaction_bytes(tx_str: str) -> bytes:
 
 
 def extract_payload_string(json_str):
-    # Find the start of the 'payload' object
-    start_index = json_str.find('"payload":')
-    if start_index == -1:
-        raise ValueError("No 'payload' found in the provided JSON string.")
-    
-    # Find the opening brace of the 'payload' object
-    start_brace_index = json_str.find('{', start_index)
-    if start_brace_index == -1:
-        raise ValueError("Malformed JSON: No opening brace for 'payload'.")
-
-    # Use a stack to find the matching closing brace
-    brace_count = 0
-    for i in range(start_brace_index, len(json_str)):
-        if json_str[i] == '{':
-            brace_count += 1
-        elif json_str[i] == '}':
-            brace_count -= 1
+    try:
+        # Find the start of the 'payload' object
+        start_index = json_str.find('"payload":')
+        if start_index == -1:
+            raise ValueError("No 'payload' found in the provided JSON string.")
         
-        # When brace_count is zero, we've found the matching closing brace
-        if brace_count == 0:
-            return json_str[start_brace_index:i+1]
-    
-    raise ValueError("Malformed JSON: No matching closing brace for 'payload'.")
+        # Find the opening brace of the 'payload' object
+        start_brace_index = json_str.find('{', start_index)
+        if start_brace_index == -1:
+            raise ValueError("Malformed JSON: No opening brace for 'payload'.")
 
+        # Use a stack to find the matching closing brace, ignoring braces within strings
+        brace_count = 0
+        in_string = False
+        i = start_brace_index
+        while i < len(json_str):
+            char = json_str[i]
+            
+            if char == '"' and (i == 0 or json_str[i-1] != '\\'):
+                in_string = not in_string
+            
+            if not in_string:
+                if char == '{':
+                    brace_count += 1
+                elif char == '}':
+                    brace_count -= 1
+            
+            # When brace_count is zero, we've found the matching closing brace
+            if brace_count == 0:
+                return json_str[start_brace_index:i+1]
+            
+            i += 1
+        
+        raise ValueError("Malformed JSON: No matching closing brace for 'payload'.")
+    except Exception as e:
+        logger.error(f"An unexpected error occurred: {e}")
+        raise
 
 def hash_bytes(bytes):
     return hashlib.sha256(bytes).hexdigest()

--- a/src/xian/utils/tx.py
+++ b/src/xian/utils/tx.py
@@ -139,12 +139,6 @@ def check_tx_formatting(tx: dict):
     check_tx_keys(tx)
     check_format(tx, TRANSACTION_RULES)
 
-    if not verify(
-            tx["payload"]["sender"], encode(tx["payload"]), tx["metadata"]["signature"]
-    ):
-        raise TransactionException('Transaction is not signed by the sender')
-
-
 def check_contract_name(contract, function, name):
     if (
             contract == "submission"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,167 @@
+import unittest
+import json
+from parameterized import parameterized
+from xian.utils.encoding import (
+    extract_payload_string,
+    decode_transaction_bytes,
+    encode_transaction_bytes,
+)
+from xian.utils.tx import unpack_transaction, verify
+
+
+class TestPayloadStrExtraction(unittest.TestCase):
+
+    @parameterized.expand(
+        [
+            (
+                "preserve_payload_as_string",
+                '{"metadata":{"signature":"f47871676c33d17d5a86bd8b2f12832e35e2b73692b0f28321be2f9acd3379c755440333ddc5e5bf40255256adb946aecae6729e8cb3a9028b08cdd995609f05"},"payload":{"chain_id":"xian-local","contract":"currency","function":"transfer","kwargs":{"amount":0.00000252,"to":"JAVASCRIPT_TRANSACTION_TEST"},"nonce":40,"sender":"e9e8aad29ce8e94fd77d9c55582e5e0c57cf81c552ba61c0d4e34b0dc11fd931","stamps_supplied":10}}',
+                True,
+            ),
+            (
+                "preserve_payload_with_nested_json_as_string",
+                '{"metadata":{"signature":"f47871676c33d17d5a86bd8b2f12832e35e2b73692b0f28321be2f9acd3379c755440333ddc5e5bf40255256adb946aecae6729e8cb3a9028b08cdd995609f05"},"payload":{"chain_id":"xian-local","contract":"currency","function":"transfer","kwargs":{"amount":0.00000252,"to":"JAVASCRIPT_TRANSACTION_TEST","nested_data":{"key1":"value1","key2":{"subkey":"subvalue"}}},"nonce":40,"sender":"e9e8aad29ce8e94fd77d9c55582e5e0c57cf81c552ba61c0d4e34b0dc11fd931","stamps_supplied":10}}',
+                True,
+            ),
+            (
+                "preserve_payload_with_deeply_nested_json_as_string",
+                '{"metadata":{"signature":"f47871676c33d17d5a86bd8b2f12832e35e2b73692b0f28321be2f9acd3379c755440333ddc5e5bf40255256adb946aecae6729e8cb3a9028b08cdd995609f05"},"payload":{"chain_id":"xian-local","contract":"currency","function":"transfer","kwargs":{"amount":0.00000252,"to":"JAVASCRIPT_TRANSACTION_TEST","nested_data":{"key1":"value1","key2":{"subkey":"subvalue","deeper":{"deep_key":"deep_value","deep_array":[{"array_key1":"array_value1"},{"array_key2":"array_value2"}]}}}},"nonce":40,"sender":"e9e8aad29ce8e94fd77d9c55582e5e0c57cf81c552ba61c0d4e34b0dc11fd931","stamps_supplied":10}}',
+                True,
+            ),
+            (
+                "bracket_in_payload_string",
+                '{"metadata":{"signature":"f47871676c33d17d5a86bd8b2f12832e35e2b73692b0f28321be2f9acd3379c755440333ddc5e5bf40255256adb946aecae6729e8cb3a9028b08cdd995609f05"},"payload":{"chain_id":"xian-local","contract":"currency","function":"transfer","kwargs":{"amount":0.00000252,"to":"JAVASCRIPT_TRANSACTION_TEST}"},"nonce":40,"sender":"e9e8aad29ce8e94fd77d9c55582e5e0c57cf81c552ba61c0d4e34b0dc11fd931","stamps_supplied":10}}',
+                True,
+            ),
+            (
+                "double_slash_escape_in_payload",
+                '{"metadata":{"signature":"abc"},"payload":{"text":"This is a \\"quoted\\" string","number":123}}',
+                True,
+            ),
+            (
+                "unicode_escapes_in_payload",
+                '{"metadata":{"signature":"abc"},"payload":{"text":"Unicode test: \\u2603 \\u2764"}}',
+                True,
+            ),
+            ("no_payload_field", '{"id": 2, "other_field": "data"}', False),
+            (
+                "empty_payload",
+                '{"id": 3, "payload": "", "other_field": "data"}',
+                False,
+            ),
+            (
+                "escaped_quotes_in_payload",
+                '{"metadata":{"signature":"abc"},"payload":{"text":"This is a \\"quoted\\" string","number":123}}',
+                True,
+            ),
+            (
+                "special_characters_in_payload",
+                '{"metadata":{"signature":"abc"},"payload":{"text":"Special characters !@#$%^&*()_+-=~`"}}',
+                True,
+            ),
+            (
+                "payload_with_empty_object",
+                '{"metadata":{"signature":"abc"},"payload":{}}',
+                True,
+            ),
+            (
+                "payload_with_empty_array",
+                '{"metadata":{"signature":"abc"},"payload":{"array":[]}}',
+                True,
+            ),
+            (
+                "payload_with_large_numbers",
+                '{"metadata":{"signature":"abc"},"payload":{"large_number":12345678901234567890}}',
+                True,
+            ),
+            (
+                "payload_with_unicode_characters",
+                '{"metadata":{"signature":"abc"},"payload":{"text":"Unicode test: \u2603 \u2764"}}',
+                True,
+            ),
+            (
+                "payload_with_boolean_values",
+                '{"metadata":{"signature":"abc"},"payload":{"flag":true,"status":false}}',
+                True,
+            ),
+            (
+                "payload_with_null_value",
+                '{"metadata":{"signature":"abc"},"payload":{"nullable":null}}',
+                True,
+            ),
+            (
+                "double-slash-escape-in-payload",
+                '{"metadata":{"signature":"abc"},"payload":{"text":"This is a \\" } quoted\\" string","number":123}}',
+                True,
+            ),
+        ]
+    )
+    def test_extract_payload(
+        self, name, tx_str, has_payload, should_match=True
+    ):
+        complete_json = json.loads(tx_str)
+        if has_payload:
+            result = json.loads(extract_payload_string(tx_str))
+            if should_match:
+                self.assertEqual(result, complete_json["payload"])
+            else:
+                self.assertNotEqual(result, complete_json["payload"])
+        else:
+            with self.assertRaises(ValueError):
+                res = extract_payload_string(tx_str)
+
+
+class TestVerification(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "valid_transaction",
+                '{"metadata":{"signature":"f47871676c33d17d5a86bd8b2f12832e35e2b73692b0f28321be2f9acd3379c755440333ddc5e5bf40255256adb946aecae6729e8cb3a9028b08cdd995609f05"},"payload":{"chain_id":"xian-local","contract":"currency","function":"transfer","kwargs":{"amount":0.00000252,"to":"JAVASCRIPT_TRANSACTION_TEST"},"nonce":40,"sender":"e9e8aad29ce8e94fd77d9c55582e5e0c57cf81c552ba61c0d4e34b0dc11fd931","stamps_supplied":10}}',
+                True,
+            ),
+            (
+                "invalid_signature",
+                '{"metadata":{"signature":"f47871676c33d17d5a86bd8b2f12832e35e2b73692b0f28321be2f9acd3379c755440333ddc5e5bf40255256adb946aecae6729e8cb3a9028b08cdd995609f04"},"payload":{"chain_id":"xian-local","contract":"currency","function":"transfer","kwargs":{"amount":0.00000252,"to":"JAVASCRIPT_TRANSACTION_TEST"},"nonce":40,"sender":"e9e8aad29ce8e94fd77d9c55582e5e0c57cf81c552ba61c0d4e34b0dc11fd931","stamps_supplied":10}}',
+                False,
+            ),
+        ]
+    )
+    def test_verify(self, name, tx_str, expected_result):
+        tx_json = json.loads(tx_str)
+        payload_str = extract_payload_string(tx_str)
+        sender, signature, payload = unpack_transaction(tx_json)
+        self.assertEqual(
+            verify(sender, payload_str, signature), expected_result
+        )
+
+
+class TestEncoding(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "valid_transaction",
+                '{"metadata":{"signature":"f47871676c33d17d5a86bd8b2f12832e35e2b73692b0f28321be2f9acd3379c755440333ddc5e5bf40255256adb946aecae6729e8cb3a9028b08cdd995609f05"},"payload":{"chain_id":"xian-local","contract":"currency","function":"transfer","kwargs":{"amount":0.00000252,"to":"JAVASCRIPT_TRANSACTION_TEST"},"nonce":40,"sender":"e9e8aad29ce8e94fd77d9c55582e5e0c57cf81c552ba61c0d4e34b0dc11fd931","stamps_supplied":10}}',
+                False,
+            ),
+            (
+                "multiple_payload_fields",
+                '{"payload":{"chain_id":"xian-local","contract":"currency","function":"transfer","kwargs":{"amount":10000000000,"to":"JAVASCRIPT_TRANSACTION_TEST"},"nonce":40,"sender":"e9e8aad29ce8e94fd77d9c55582e5e0c57cf81c552ba61c0d4e34b0dc11fd931","stamps_supplied":10}, "metadata":{"signature":"847871676c33d17d5a86bd8b2f12832e35e2b73692b0f28321be2f9acd3379c755440333ddc5e5bf40255256adb946aecae6729e8cb3a9028b08cdd995609f05"},"payload":{"chain_id":"xian-local","contract":"currency","function":"transfer","kwargs":{"amount":0.00000252,"to":"JAVASCRIPT_TRANSACTION_TEST"},"nonce":40,"sender":"e9e8aad29ce8e94fd77d9c55582e5e0c57cf81c552ba61c0d4e34b0dc11fd931","stamps_supplied":10}}',
+                True,
+            ),
+        ]
+    )
+    def test_decode_transaction_bytes(self, name, tx_str, should_raise):
+        tx_bytes = encode_transaction_bytes(tx_str)
+        if should_raise:
+            with self.assertRaises(AssertionError) as context:
+                tx_json_decoded, payload_str = decode_transaction_bytes(
+                    tx_bytes
+                )
+            self.assertTrue("Invalid payload" in str(context.exception))
+        else:
+            tx_json_decoded, payload_str = decode_transaction_bytes(tx_bytes)
+        # self.assertEqual(tx_json_decoded, tx_json)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

When the node receives a transaction, it deserialises the transaction JSON to a dict, part of this process is that small numbers (e.g 0.0000025) are converted to exponential notation. This is causing the signature verification step to fail when the transaction is not sent from python.

This fix changes the way the tx is handled - the `payload` is now extracted from the tx as a string, which is then used to verify the signature against.

Additionally, this PR also includes the removal of some redundant verification steps - in finalise_tx and in check_tx (where it was being done twice.)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [] I have tested this change in my development environment.
- [x] I have added tests to prove that this change works
- [x] All existing tests pass after this change