### PR TITLE
Adjust 'stamp calculator' to be a 'tx simulator'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ up:
 	pm2 start "../cometbft node --rpc.laddr tcp://0.0.0.0:26657" --name cometbft -f
 
 up-bds:
-	cd ./src/xian/services/ && pm2 start stamp_calculator.py --name stamp_calculator -f --wait-ready
+	cd ./src/xian/services/ && pm2 start simulator.py --name simulator -f --wait-ready
 	cd ./src/xian && pm2 start xian_abci.py --name xian -f
 	pm2 start "../cometbft node --rpc.laddr tcp://0.0.0.0:26657" --name cometbft -f
 

--- a/src/xian/constants.py
+++ b/src/xian/constants.py
@@ -5,7 +5,7 @@ class Constants:
     COMETBFT_CONFIG = COMETBFT_HOME / Path("config/config.toml")
     COMETBFT_GENESIS = COMETBFT_HOME / Path("config/genesis.json")
     STORAGE_HOME = COMETBFT_HOME / Path('xian/')
-    STAMPESTIMATOR_SOCKET = '/tmp/stampestimator.sock'
+    SIMULATOR_SOCKET = '/tmp/simulator.sock'
 
     NONCE_FILENAME = '__n'
     PENDING_NONCE_FILENAME = '__pn'

--- a/src/xian/methods/query.py
+++ b/src/xian/methods/query.py
@@ -157,6 +157,21 @@ async def query(self, req) -> ResponseQuery:
                 except:
                     result = {"stdout": "", "stderr": ""}
 
+            # http://localhost:26657/abci_query?path="/simulate_tx/<encoded_payload>"
+            elif path_parts[0] == "simulate_tx":
+                connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                connection.connect(c.STAMPESTIMATOR_SOCKET)
+
+                raw_tx = path_parts[1]
+                byte_data = bytes.fromhex(raw_tx)
+                message_length = struct.pack('>I', len(byte_data))
+                connection.sendall(message_length + byte_data)
+                recv_length = connection.recv(4)
+                length = struct.unpack('>I', recv_length)[0]
+                recv = connection.recv(length)
+                result = recv.decode()
+
+            # TODO: Deprecated - Remove after wallet and tools are reworked to use 'simulate_tx'
             # http://localhost:26657/abci_query?path="/calculate_stamps/<encoded_payload>"
             elif path_parts[0] == "calculate_stamps":
                 connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/src/xian/methods/query.py
+++ b/src/xian/methods/query.py
@@ -157,7 +157,7 @@ async def query(self, req) -> ResponseQuery:
                 except:
                     result = {"stdout": "", "stderr": ""}
 
-            # http://localhost:26657/abci_query?path="/calculate_stamps/<encoded_tx>"
+            # http://localhost:26657/abci_query?path="/calculate_stamps/<encoded_payload>"
             elif path_parts[0] == "calculate_stamps":
                 connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 connection.connect(c.STAMPESTIMATOR_SOCKET)

--- a/src/xian/methods/query.py
+++ b/src/xian/methods/query.py
@@ -160,7 +160,7 @@ async def query(self, req) -> ResponseQuery:
             # http://localhost:26657/abci_query?path="/simulate_tx/<encoded_payload>"
             elif path_parts[0] == "simulate_tx":
                 connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                connection.connect(c.STAMPESTIMATOR_SOCKET)
+                connection.connect(c.SIMULATOR_SOCKET)
 
                 raw_tx = path_parts[1]
                 byte_data = bytes.fromhex(raw_tx)
@@ -175,7 +175,7 @@ async def query(self, req) -> ResponseQuery:
             # http://localhost:26657/abci_query?path="/calculate_stamps/<encoded_payload>"
             elif path_parts[0] == "calculate_stamps":
                 connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                connection.connect(c.STAMPESTIMATOR_SOCKET)
+                connection.connect(c.SIMULATOR_SOCKET)
 
                 raw_tx = path_parts[1]
                 byte_data = bytes.fromhex(raw_tx)

--- a/src/xian/services/simulator.py
+++ b/src/xian/services/simulator.py
@@ -130,7 +130,6 @@ class Simulator:
             payload=payload,
             environment=environment,
             stamp_cost=stamp_cost,
-            driver=driver,
             executor=executor
         )
 

--- a/src/xian/services/simulator.py
+++ b/src/xian/services/simulator.py
@@ -87,7 +87,7 @@ class Simulator:
         # Generate a random number with `length//2` bytes and convert to hex
         return secrets.token_hex(nbytes=length // 2)
 
-    def execute_tx(self, payload, stamp_cost, environment: dict = {}, driver=None, executor=None):
+    def execute_tx(self, payload, stamp_cost, environment: dict = {}, executor=None):
 
         balance = 9999999
         output = executor.execute(

--- a/src/xian/services/simulator.py
+++ b/src/xian/services/simulator.py
@@ -13,19 +13,19 @@ import json
 import struct
 
 
-class StampCalculator:
+class Simulator:
     def __init__(self):
         self.constants = Constants()
 
     def setup_socket(self):
         # If the socket file exists, remove it
-        STAMPESTIMATOR_SOCKET = pathlib.Path(self.constants.STAMPESTIMATOR_SOCKET)
-        if STAMPESTIMATOR_SOCKET.exists():
-            STAMPESTIMATOR_SOCKET.unlink()
+        simulator_socket = pathlib.Path(self.constants.SIMULATOR_SOCKET)
+        if simulator_socket.exists():
+            simulator_socket.unlink()
 
         # Create a socket
         self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.socket.bind(self.constants.STAMPESTIMATOR_SOCKET)
+        self.socket.bind(self.constants.SIMULATOR_SOCKET)
         self.socket.listen(1)
 
     def listen(self):
@@ -136,6 +136,6 @@ class StampCalculator:
 
 
 if __name__ == '__main__':
-    sc = StampCalculator()
+    sc = Simulator()
     sc.setup_socket()
     sc.listen()


### PR DESCRIPTION
## Description

This will give us the possibility to simulate transactions by only supplying the encoded payload dict. No signing needed. Since this is more than just a stamp calculator, I renamed it to 'simulator'.

This is tested and working. I've also reworked `xian-py` to reflect these adjustments and explicitly added a method to simulate transactions: https://github.com/xian-network/xian-py/pull/2

To have it really clean and making sense, I've added a `simulate_tx` endpoint to [query.py](https://github.com/xian-network/xian-core/blob/stamp_calc_payload/src/xian/methods/query.py#L161) that should over time replace the `calculate_stamps` endpoint.

**Our Chrome wallet and possibly JS tools would need to be adjusted** 

Example script
```python
from xian_py.wallet import Wallet
from xian_py.xian import Xian
from xian_py.transaction import (
    get_nonce,
    simulate_tx
)

node_url = 'http://127.0.0.1:26657'
wallet = Wallet('cd6cc45ffe7cebf09c6c6025575d50bb42c6c70c07e1dbc5150aaadc98705c2b')

xian = Xian(
    node_url,
    wallet=wallet
)

payload = {
    "contract": "currency",
    "function": "transfer",
    "kwargs":
    {
        "to": "8bf21c7dc3a4ff32996bf56a665e1efe3c9261cc95bbf82552c328585c863829",
        "amount": 1.11,
    },
    "nonce": get_nonce(node_url, wallet.public_key),
    "stamps": 0,
    "chain_id": xian.get_chain_id(),
    "sender": wallet.public_key
}
print(f'payload: {payload}')

simulated_tx = simulate_tx(node_url, payload)
print(f'simulated tx: {simulated_tx}')
```

Endpoint INPUT
```python
{
    'contract': 'currency',
    'function': 'transfer',
    'kwargs':
    {
        'to': '8bf21c7dc3a4ff32996bf56a665e1efe3c9261cc95bbf82552c328585c863829',
        'amount': 1.11
    },
    'nonce': 2,
    'stamps': 0,
    'chain_id': 'unique-chain-id-goes-here',
    'sender': 'ee06a34cf08bf72ce592d26d36b90c79daba2829ba9634992d034318160d49f9'
}
```

Endpoint OUTPUT
```python
{
    'payload':
    {
        'chain_id': 'unique-chain-id-goes-here',
        'contract': 'currency',
        'function': 'transfer',
        'kwargs':
        {
            'amount': 1.11,
            'to': '8bf21c7dc3a4ff32996bf56a665e1efe3c9261cc95bbf82552c328585c863829'
        },
        'nonce': 2,
        'sender': 'ee06a34cf08bf72ce592d26d36b90c79daba2829ba9634992d034318160d49f9',
        'stamps': 0
    },
    'result': 'None',
    'stamps_used': 10,
    'state': [
    {
        'key': 'currency.balances:ee06a34cf08bf72ce592d26d36b90c79daba2829ba9634992d034318160d49f9',
        'value': '61111008.32100000'
    },
    {
        'key': 'currency.balances:8bf21c7dc3a4ff32996bf56a665e1efe3c9261cc95bbf82552c328585c863829',
        'value': '2.22'
    }],
    'status': 0
}
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change