### PR TITLE
Pass string instead of datetime object

### DIFF
--- a/src/xian/services/simulator.py
+++ b/src/xian/services/simulator.py
@@ -89,7 +89,7 @@ class Simulator:
             'block_hash': random_hex_string,
             'block_num': num,
             '__input_hash': random_hex_string,
-            'now': datetime.now(),
+            'now': str(datetime.now()),
             'AUXILIARY_SALT': random_hex_string
         }
 

--- a/src/xian/services/stamp_calculator.py
+++ b/src/xian/services/stamp_calculator.py
@@ -79,7 +79,7 @@ class StampCalculator:
             'block_hash': self.generate_random_hex_string(),
             'block_num': num,
             '__input_hash': self.generate_random_hex_string(),
-            'now': now,
+            'now': str(now),
             'AUXILIARY_SALT': self.generate_random_hex_string()
         }
 


### PR DESCRIPTION
## Description

In the simulator / stamp calculator we need to pass the `now` object as a string and not as `datetime` since that is not JSON serializable. If a contract uses `now` without this fix, then the simulation of that transaction will result in an error.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change
