### PR TITLE
Fixed issue with datetime objects

### DIFF
--- a/src/xian/services/simulator.py
+++ b/src/xian/services/simulator.py
@@ -5,10 +5,11 @@ import json
 import struct
 
 from loguru import logger
+from datetime import datetime
 from contracting.execution.executor import Executor
+from contracting.stdlib.bridge.time import Datetime
 from contracting.storage.encoder import safe_repr, convert_dict
 from contracting.storage.driver import Driver
-from datetime import datetime
 from xian.utils.tx import format_dictionary
 from xian.utils.encoding import stringify_decimals
 from xian.constants import Constants as c
@@ -89,7 +90,7 @@ class Simulator:
             'block_hash': random_hex_string,
             'block_num': num,
             '__input_hash': random_hex_string,
-            'now': str(datetime.now()),
+            'now': Datetime._from_datetime(datetime.now()),
             'AUXILIARY_SALT': random_hex_string
         }
 


### PR DESCRIPTION
## Description

I previously replaced `Datetime._from_datetime(datetime.now())` with `datetime.now()` but that was a mistake. It's not the same because the previous code uses our own `Datetime` object from the `time` module and that's needed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change
