### PR TITLE
Fixed issue with datetime objects (old impl)

### DIFF
--- a/src/xian/services/stamp_calculator.py
+++ b/src/xian/services/stamp_calculator.py
@@ -79,7 +79,7 @@ class StampCalculator:
             'block_hash': self.generate_random_hex_string(),
             'block_num': num,
             '__input_hash': self.generate_random_hex_string(),
-            'now': str(now),
+            'now': now,
             'AUXILIARY_SALT': self.generate_random_hex_string()
         }
 


### PR DESCRIPTION
## Description

I previously replaced Datetime._from_datetime(datetime.now()) with datetime.now() but that was a mistake. It's not the same because the previous code uses our own Datetime object from the time module and that's needed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change
