### PR TITLE
Decompile contract source-code first before saving

### DIFF
--- a/src/xian/services/bds/bds.py
+++ b/src/xian/services/bds/bds.py
@@ -7,6 +7,7 @@ from xian.services.bds.config import Config
 from contracting.stdlib.bridge.decimal import ContractingDecimal
 from contracting.stdlib.bridge.time import Datetime, Timedelta
 from xian.services.bds.database import DB, result_to_json
+from xian_py.decompiler import ContractDecompiler
 from xian_py.wallet import key_is_valid
 from timeit import default_timer as timer
 from decimal import Decimal
@@ -376,12 +377,14 @@ class BDS:
         ])
 
     async def insert_genesis_state_contract(self, contract_name, code, submission_time):
+        original_code = ContractDecompiler().decompile(code)
+
         try:
             await self.db.execute(sql.insert_contracts(), [
                 f"GENESIS",
                 contract_name,
-                code,
-                self.is_XSC0001(code),
+                original_code,
+                self.is_XSC0001(original_code),
                 submission_time
             ])
         except Exception as e:


### PR DESCRIPTION
## Description

Decompile contract source-code first before checking if it is a token contract and before saving it in BDS.

**This change requires `xian-py` with at least version 0.3.6**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change
