### PR TITLE
Allow to execute read-only transactions for free

### DIFF
--- a/src/xian/methods/query.py
+++ b/src/xian/methods/query.py
@@ -62,6 +62,8 @@ async def query(self, req) -> ResponseQuery:
                 kwargs=tx_payload['kwargs']
             )
 
+            result = str(result['result'])
+
         # http://localhost:26657/abci_query?path="/health"
         elif path_parts[0] == "health":
             result = "OK"


### PR DESCRIPTION
## Description

Added read-only transaction execution endpoint to support fee-less state queries:

1. New `ReadOnlyDriver` implementation that disables all state-modifying operations
2. New `ReadOnlyExecutor` class that uses the read-only driver and executes transactions without stamps/metering
3. Added `/execute_read_only` endpoint in query.py that:
   - Takes a transaction payload 
   - Uses ReadOnlyExecutor to execute it without fees
   - Returns just the query result value as a string

This allows clients to execute functions (e.g. calculations, validations) from contracts. All without paying transaction fees, while maintaining security by preventing state modifications.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change
