### PR TITLE
staking

### DIFF
--- a/src/xian/tools/genesis/contracts/members.s.py
+++ b/src/xian/tools/genesis/contracts/members.s.py
@@ -150,6 +150,7 @@ def delegate(amount: float, node: str):
     assert pending_undelegates[node, ctx.caller] == False, "Must wait for pending undelegate to finish"
     currency.transfer_from(amount=amount, to=ctx.this, main_account=ctx.caller)
     delegate_holdings[node, ctx.caller] += amount
+    return "Delegated"
 
 @export
 def undelegate(amount: float, node: str):
@@ -157,8 +158,10 @@ def undelegate(amount: float, node: str):
     if pending_undelegates[node, ctx.caller] == False:
         pending_undelegates[node, ctx.caller] = now + timedelta(days=7)
         return "Undelegate request pending for 7 days"
-    else:
-        assert pending_undelegates[node, ctx.caller] < now, "Undelegate request not over"
+    elif pending_undelegates[node, ctx.caller] < now:
+        return "Undelegate request period not yet over"
+    elif pending_undelegates[node, ctx.caller] >= now:
         currency.transfer(delegate_holdings[node, ctx.caller], ctx.caller)
         delegate_holdings[node, ctx.caller] = 0
         pending_undelegates[node, ctx.caller] = False
+        return "Undelegate request complete"

--- a/src/xian/tools/genesis/contracts/members.s.py
+++ b/src/xian/tools/genesis/contracts/members.s.py
@@ -165,3 +165,9 @@ def undelegate(amount: float, node: str):
         delegate_holdings[node, ctx.caller] = 0
         pending_undelegates[node, ctx.caller] = False
         return "Undelegate request complete"
+
+@export
+def get_total_power(node: str):
+    delegates = sum([delegate_holdings[node, delegator] for delegator in delegate_holdings.keys() if delegator == node])
+    node_power = node_holdings[node]
+    return delegates + node_power

--- a/src/xian/tools/genesis/contracts/members.s.py
+++ b/src/xian/tools/genesis/contracts/members.s.py
@@ -167,7 +167,12 @@ def undelegate(amount: float, node: str):
         return "Undelegate request complete"
 
 @export
-def get_total_power(node: str):
+def get_total_power_of_node(node: str):
+    assert node in nodes.get(), "Not a node"
     delegates = sum([delegate_holdings[node, delegator] for delegator in delegate_holdings.keys() if delegator == node])
     node_power = node_holdings[node]
     return delegates + node_power
+
+@export
+def get_total_power():
+    return sum([get_total_power_of_node(node) for node in nodes.get()])


### PR DESCRIPTION
## Description

Delegate and Undelegate function
- everyones delegation to different nodes is tracked
- undelegation takes 7 days and can then be withdrawn

get_total_power_of_node can be used to get the full voting power of a node. Instead of the dao using a +1 vote when voting, it will instead add the power as the vote amount by calling this function when voting (we don’t need to involve cometbft node power here)

get_total_power can be used to get the total to compare against when voting for sufficient votes 