### PR TITLE
Cleanup logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ contracting
 lamden
 /xian_venv
 cometbft
+logs

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ logs:
 	pm2 logs --lines 1000
 
 down:
+	pm2 stop all
+	sleep 5  # Give Loguru time to handle any final cleanup
 	pm2 delete all
 
 restart:

--- a/src/xian/xian_abci.py
+++ b/src/xian/xian_abci.py
@@ -5,11 +5,10 @@ import gc
 import asyncio
 import signal
 
-from xian.constants import Constants
-
 from loguru import logger
 from datetime import timedelta, datetime
 from abci.server import ABCIServer
+from xian.constants import Constants
 from xian.services.bds.bds import BDS
 from contracting.client import ContractingClient
 
@@ -40,6 +39,8 @@ from abci.utils import get_logger
 get_logger("requests").setLevel(30)
 get_logger("urllib3").setLevel(30)
 get_logger("asyncio").setLevel(30)
+
+LOG_RETENTION_DAYS = 3
 
 
 def load_module(module_path, original_module_path):
@@ -209,11 +210,11 @@ def main():
     os.makedirs(logs_dir, exist_ok=True)
 
     # Clean up old logs on startup
-    cleanup_old_logs(logs_dir)
+    cleanup_old_logs(logs_dir, days=LOG_RETENTION_DAYS)
 
     logger.add(
         os.path.join(log_path, 'logs', '{time}.log'),
-        retention=timedelta(days=3),
+        retention=timedelta(days=LOG_RETENTION_DAYS),
         rotation=timedelta(hours=1),
         format="{time} {level} {name} {message}",
         level="DEBUG",


### PR DESCRIPTION
## Description

Added a custom function that runs on startup and cleans old logs. This is definitely working now. Additionally added `sleep 5` to `make down` to give loguru time to clean up old logs and compress current logs.

## Type of change

- [x] Enhancement (simplifying, beautifying, better performance, etc.)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change
