### PR TITLE
Adjust to new `xian-py` structure

### DIFF
--- a/src/xian/services/bds/bds.py
+++ b/src/xian/services/bds/bds.py
@@ -8,7 +8,7 @@ from contracting.stdlib.bridge.decimal import ContractingDecimal
 from contracting.stdlib.bridge.time import Datetime, Timedelta
 from xian.services.bds.database import DB, result_to_json
 from xian_py.decompiler import ContractDecompiler
-from xian_py.wallet import key_is_valid
+from xian_py.wallet import Wallet
 from timeit import default_timer as timer
 from decimal import Decimal
 
@@ -234,7 +234,7 @@ class BDS:
         for state_change in tx['tx_result']['state']:
             if state_change['key'].startswith('currency.balances:'):
                 address = state_change['key'].replace('currency.balances:', '')
-                if key_is_valid(address):
+                if Wallet.is_valid_key(address):
                     try:
                         self.db.add_query_to_batch(sql.insert_addresses(), [
                             tx['tx_result']['hash'],


### PR DESCRIPTION
## Description

`xian-py` recently got an update which changed a few things. This adjustment is needed so that `xian-core` can be used with the newest version of `xian-py` again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested this change in my development environment.
- [ ] I have added tests to prove that this change works
- [ ] All existing tests pass after this change
- [ ] I have added / updated documentation related to this change
