### PR TITLE
Ensure snapshot manager is initialized before use

### DIFF
--- a/src/xian/methods/finalize_block.py
+++ b/src/xian/methods/finalize_block.py
@@ -153,8 +153,9 @@ async def finalize_block(self, req) -> ResponseFinalizeBlock:
     self.merkle_root_hash = latest_block_hash if (len(req.txs) == 0 and not state_patch_applied) else hash_list(self.fingerprint_hashes)
 
     # Create state snapshot if needed (for fast sync)
-    if hasattr(self, 'snapshot_manager') and self.snapshot_manager is not None:
-        if self.snapshot_manager.should_create_snapshot(height):
+    if hasattr(self, 'snapshot_manager'):
+        snapshot_manager = self._ensure_snapshot_manager()
+        if snapshot_manager.should_create_snapshot(height):
             asyncio.create_task(self._create_snapshot_async(height, self.merkle_root_hash, nanos))
 
     return ResponseFinalizeBlock(


### PR DESCRIPTION
## Summary
- add a helper to lazily instantiate the state snapshot manager in the ABCI service
- ensure finalize_block always acquires a snapshot manager before evaluating snapshot schedules

## Testing
- pytest *(fails: missing optional xian/contracting modules in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f02c42c483209f54546bfa3af0ab